### PR TITLE
Add R3GAN support - modern GAN baseline with SOTA FID scores

### DIFF
--- a/R3GAN_INTEGRATION_PLAN.md
+++ b/R3GAN_INTEGRATION_PLAN.md
@@ -1,0 +1,233 @@
+# R3GAN Integration Plan for Lucid Sonic Dreams
+
+## Executive Summary
+
+R3GAN is a modern GAN baseline that achieves state-of-the-art results while being simpler than StyleGAN2/3. This plan outlines how to integrate R3GAN into lucid-sonic-dreams to provide users with an alternative, potentially higher-quality generator.
+
+## Key R3GAN Characteristics
+
+### Architecture
+- **Loss Function**: RpGAN + R1 + R2 (regularized relativistic GAN)
+- **Network**: ConvNeXt-inspired ResNet with 1-3-1 bottlenecks
+- **No StyleGAN tricks**: No minibatch stddev, no equalized LR, no path length regularization
+
+### Interface Compatibility
+R3GAN uses the **same interface as StyleGAN2/3**:
+```python
+# Loading (identical)
+G = legacy.load_network_pkl(f)['G_ema'].to(device)
+
+# Generation (can use single call OR mapping+synthesis)
+img = G(z, label)                           # Single call
+# OR
+w = G.mapping(z, label)                     # Two-step
+img = G.synthesis(w)
+```
+
+### Attributes (same as StyleGAN)
+- `G.z_dim` - Latent dimension (512)
+- `G.c_dim` - Class conditioning dimension
+- `G.w_dim` - Intermediate latent dimension (512)
+- `G.img_resolution` - Output resolution
+
+## Available Pretrained Models
+
+| Model | Resolution | Classes | FID | Use Case |
+|-------|------------|---------|-----|----------|
+| R3GAN-CIFAR10 | 32x32 | 10 | 1.96 | Testing |
+| R3GAN-FFHQ-64x64 | 64x64 | 0 | 1.95 | Faces |
+| R3GAN-FFHQ-256x256 | 256x256 | 0 | 2.75 | Faces (HQ) |
+| R3GAN-ImgNet-32x32 | 32x32 | 1000 | 1.27 | Objects |
+| R3GAN-ImgNet-64x64 | 64x64 | 1000 | 2.09 | Objects |
+
+## Integration Architecture
+
+### Phase 1: Minimal Integration (Recommended First)
+
+Since R3GAN uses the same pickle format and similar interface as StyleGAN, we can:
+
+1. **Add R3GAN to the model registry** in `helper_functions.py`
+2. **Update model download URLs** to include HuggingFace R3GAN models
+3. **Detect R3GAN models** and handle any interface differences
+
+### Phase 2: Enhanced Support
+
+1. **Dedicated R3GAN setup function** (similar to `setup_stylegan()`)
+2. **Performance optimizations** specific to R3GAN
+3. **Documentation and examples**
+
+## Implementation Details
+
+### Step 1: Update Model Registry
+
+Add R3GAN models to `helper_functions.py`:
+
+```python
+R3GAN_MODELS = {
+    'r3gan_ffhq_256': {
+        'url': 'https://huggingface.co/brownvc/R3GAN-FFHQ-256x256/resolve/main/ffhq-256x256.pkl',
+        'resolution': 256,
+        'num_classes': 0,
+        'type': 'r3gan'
+    },
+    'r3gan_ffhq_64': {
+        'url': 'https://huggingface.co/brownvc/R3GAN-FFHQ-64x64/resolve/main/ffhq-64x64.pkl',
+        'resolution': 64,
+        'num_classes': 0,
+        'type': 'r3gan'
+    },
+    'r3gan_cifar10': {
+        'url': 'https://huggingface.co/brownvc/R3GAN-CIFAR10/resolve/main/cifar10.pkl',
+        'resolution': 32,
+        'num_classes': 10,
+        'type': 'r3gan'
+    },
+    'r3gan_imagenet_64': {
+        'url': 'https://huggingface.co/brownvc/R3GAN-ImgNet-64x64/resolve/main/imagenet-64x64.pkl',
+        'resolution': 64,
+        'num_classes': 1000,
+        'type': 'r3gan'
+    },
+    'r3gan_imagenet_32': {
+        'url': 'https://huggingface.co/brownvc/R3GAN-ImgNet-32x32/resolve/main/imagenet-32x32.pkl',
+        'resolution': 32,
+        'num_classes': 1000,
+        'type': 'r3gan'
+    }
+}
+```
+
+### Step 2: Setup R3GAN Repository
+
+Create `setup_r3gan()` function in `main.py`:
+
+```python
+def setup_r3gan(base_dir):
+    """Clone and setup R3GAN repository"""
+    r3gan_path = os.path.join(base_dir, 'R3GAN')
+
+    if not os.path.exists(r3gan_path):
+        subprocess.run([
+            'git', 'clone',
+            'https://github.com/brownvc/R3GAN.git',
+            r3gan_path
+        ], check=True)
+
+    return r3gan_path
+```
+
+### Step 3: Model Detection and Loading
+
+Update `stylegan_init()` to detect R3GAN models:
+
+```python
+def stylegan_init(self):
+    # ... existing code ...
+
+    # Detect model type
+    self.model_type = 'stylegan'  # default
+    if hasattr(self.Gs, 'model_type'):
+        self.model_type = self.Gs.model_type
+    elif 'r3gan' in self.style.lower():
+        self.model_type = 'r3gan'
+
+    # R3GAN-specific handling
+    if self.model_type == 'r3gan':
+        # R3GAN may need different initialization
+        pass
+```
+
+### Step 4: Inference Compatibility
+
+R3GAN supports both interfaces. The current lucid-sonic-dreams code uses:
+```python
+w_batch = self.Gs.mapping(noise_tensor, class_batch)
+image_batch = self.Gs.synthesis(w_batch, **Gs_syn_kwargs)
+```
+
+For R3GAN, we may need to check if the model supports this interface or use the simpler:
+```python
+image_batch = self.Gs(noise_tensor, class_batch)
+```
+
+### Step 5: Update Documentation
+
+Add R3GAN examples to README:
+
+```python
+from lucidsonicdreams import LucidSonicDream
+
+# Use R3GAN for face generation (better quality)
+L = LucidSonicDream(
+    song='my_song.mp3',
+    style='r3gan_ffhq_256'  # R3GAN FFHQ model
+)
+L.hallucinate('output.mp4')
+
+# Use R3GAN for class-conditional generation
+L = LucidSonicDream(
+    song='my_song.mp3',
+    style='r3gan_imagenet_64',
+    num_possible_classes=1000
+)
+L.hallucinate('output.mp4')
+```
+
+## Key Differences to Handle
+
+| Aspect | StyleGAN3 | R3GAN |
+|--------|-----------|-------|
+| Repository | NVlabs/stylegan3 | brownvc/R3GAN |
+| Inference | mapping() + synthesis() | Same OR single forward() |
+| FP16 Support | Full | BFloat16 preferred |
+| Noise mode | 'const', 'random', etc. | Check support |
+
+## Testing Plan
+
+1. **Unit Tests**
+   - Model loading
+   - Single image generation
+   - Batch generation
+   - Class-conditional generation
+
+2. **Integration Tests**
+   - Full hallucination pipeline with R3GAN
+   - Audio-reactive generation quality
+   - Performance benchmarks vs StyleGAN3
+
+3. **Visual Quality Tests**
+   - FID comparison on generated video frames
+   - Temporal coherence assessment
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|------------|
+| Interface incompatibility | Use single-call G(z, c) as fallback |
+| Missing mapping/synthesis | Detect and adapt |
+| BFloat16 issues | Fall back to FP32 |
+| Repository changes | Pin specific commit |
+
+## Timeline
+
+1. **Phase 1** (Core Integration): Add model registry, setup function, basic loading
+2. **Phase 2** (Testing): Verify all models work, benchmark performance
+3. **Phase 3** (Documentation): Update README, add examples
+4. **Phase 4** (Optimization): Performance tuning, advanced features
+
+## Files to Modify
+
+1. `lucidsonicdreams/helper_functions.py` - Add R3GAN model registry
+2. `lucidsonicdreams/main.py` - Add setup_r3gan(), update stylegan_init()
+3. `README.md` - Add R3GAN documentation
+4. `setup.py` - Add any new dependencies (if needed)
+
+## Conclusion
+
+R3GAN integration is straightforward due to interface compatibility with StyleGAN. The main work involves:
+1. Adding model URLs
+2. Setting up the R3GAN repository
+3. Handling minor interface differences
+4. Testing and documentation
+
+The benefits include potentially better visual quality (lower FID scores) while maintaining the same workflow users are familiar with.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Lucid Sonic Dreams
 Lucid Sonic Dreams syncs GAN-generated visuals to music!
 
-By default, it uses [NVLabs StyleGAN2-ada-pytorch](https://github.com/NVlabs/stylegan2-ada-pytorch).
-It can also use pre-trained models lifted from [Justin Pinkney's consolidated repository](https://github.com/justinpinkney/awesome-pretrained-stylegan2), but
-these are untested.
-
-"save_frames" is no longer used as this version works in RAM and doesn't save frames to disk.
+Supports multiple GAN architectures:
+- **R3GAN** (NEW!) - Modern GAN baseline with state-of-the-art FID scores ([Paper](https://arxiv.org/abs/2501.05441))
+- **StyleGAN3** - NVIDIA's alias-free GAN ([Repo](https://github.com/NVlabs/stylegan3))
+- **StyleGAN2** - Pre-trained models from [Justin Pinkney's repository](https://github.com/justinpinkney/awesome-pretrained-stylegan2)
 
 Sample output can be found on [YouTube](https://www.youtube.com/watch?v=SDf7a28cSVs).
 
@@ -46,14 +45,42 @@ Refer to the [Lucid Sonic Dreams Tutorial Notebook](https://colab.research.googl
 
 ### Basic Visualization
 
-```
+```python
 from lucidsonicdreams import LucidSonicDream
-
 
 L = LucidSonicDream(song = 'song.mp3',
                     style = 'abstract photos')
 
-L.hallucinate(file_name = 'song.mp4') 
+L.hallucinate(file_name = 'song.mp4')
 ```
+
+### R3GAN Models (Recommended)
+
+R3GAN achieves better visual quality (lower FID) than StyleGAN2 with a simpler architecture:
+
+```python
+from lucidsonicdreams import LucidSonicDream, show_r3gan_styles
+
+# See available R3GAN models
+show_r3gan_styles()
+
+# Use R3GAN for face generation (FID: 2.75 vs StyleGAN2's 3.78)
+L = LucidSonicDream(song='song.mp3', style='r3gan_ffhq_256')
+L.hallucinate(file_name='faces.mp4')
+
+# Use R3GAN for class-conditional generation (1000 ImageNet classes)
+L = LucidSonicDream(song='song.mp3', style='r3gan_imagenet_64')
+L.hallucinate(file_name='objects.mp4')
+```
+
+**Available R3GAN Models:**
+| Model | Resolution | Classes | FID | Description |
+|-------|------------|---------|-----|-------------|
+| `r3gan_ffhq_256` | 256x256 | 0 | 2.75 | High-quality faces |
+| `r3gan_ffhq_64` | 64x64 | 0 | 1.95 | Fast face generation |
+| `r3gan_cifar10` | 32x32 | 10 | 1.96 | 10-class conditional |
+| `r3gan_imagenet_64` | 64x64 | 1000 | 2.09 | 1000-class conditional |
+| `r3gan_imagenet_32` | 32x32 | 1000 | 1.27 | 1000-class conditional |
+
 sg2-ada-pt-song-spleeter.py is an example with a variety of configuration options as defaults, based on the audio being split into 4 stems using spleeter - https://github.com/deezer/spleeter
 

--- a/lucidsonicdreams/__init__.py
+++ b/lucidsonicdreams/__init__.py
@@ -4,10 +4,12 @@ from .main import (
     EffectsGenerator,
     # Utility functions
     show_styles,
+    show_r3gan_styles,
     is_colab,
     get_temp_dir,
     get_stylegan_base_dir,
     setup_stylegan,
+    setup_r3gan,
     get_gpu_memory_mb,
     get_free_gpu_memory_mb,
     estimate_memory_usage_mb,
@@ -20,14 +22,18 @@ from .main import (
     DownloadError,
 )
 
+from .helper_functions import R3GAN_MODELS, is_r3gan_style
+
 __all__ = [
     'LucidSonicDream',
     'EffectsGenerator',
     'show_styles',
+    'show_r3gan_styles',
     'is_colab',
     'get_temp_dir',
     'get_stylegan_base_dir',
     'setup_stylegan',
+    'setup_r3gan',
     'get_gpu_memory_mb',
     'get_free_gpu_memory_mb',
     'estimate_memory_usage_mb',
@@ -37,4 +43,7 @@ __all__ = [
     'StyleNotFoundError',
     'InvalidParameterError',
     'DownloadError',
+    # R3GAN support
+    'R3GAN_MODELS',
+    'is_r3gan_style',
 ]

--- a/lucidsonicdreams/helper_functions.py
+++ b/lucidsonicdreams/helper_functions.py
@@ -11,6 +11,62 @@ import gdown
 from mega import Mega
 
 
+# =============================================================================
+# R3GAN Model Registry
+# =============================================================================
+# R3GAN: A Modern GAN Baseline (NeurIPS 2024)
+# Paper: https://arxiv.org/abs/2501.05441
+# Code: https://github.com/brownvc/R3GAN
+
+R3GAN_MODELS = {
+    'r3gan_ffhq_256': {
+        'name': 'r3gan_ffhq_256',
+        'download_url': 'https://huggingface.co/brownvc/R3GAN-FFHQ-256x256/resolve/main/ffhq-256x256.pkl',
+        'resolution': 256,
+        'num_classes': 0,
+        'type': 'r3gan',
+        'description': 'R3GAN FFHQ 256x256 - High quality faces (FID: 2.75)',
+    },
+    'r3gan_ffhq_64': {
+        'name': 'r3gan_ffhq_64',
+        'download_url': 'https://huggingface.co/brownvc/R3GAN-FFHQ-64x64/resolve/main/ffhq-64x64.pkl',
+        'resolution': 64,
+        'num_classes': 0,
+        'type': 'r3gan',
+        'description': 'R3GAN FFHQ 64x64 - Fast face generation (FID: 1.95)',
+    },
+    'r3gan_cifar10': {
+        'name': 'r3gan_cifar10',
+        'download_url': 'https://huggingface.co/brownvc/R3GAN-CIFAR10/resolve/main/cifar10.pkl',
+        'resolution': 32,
+        'num_classes': 10,
+        'type': 'r3gan',
+        'description': 'R3GAN CIFAR-10 - 10-class conditional (FID: 1.96)',
+    },
+    'r3gan_imagenet_64': {
+        'name': 'r3gan_imagenet_64',
+        'download_url': 'https://huggingface.co/brownvc/R3GAN-ImgNet-64x64/resolve/main/imagenet-64x64.pkl',
+        'resolution': 64,
+        'num_classes': 1000,
+        'type': 'r3gan',
+        'description': 'R3GAN ImageNet 64x64 - 1000-class conditional (FID: 2.09)',
+    },
+    'r3gan_imagenet_32': {
+        'name': 'r3gan_imagenet_32',
+        'download_url': 'https://huggingface.co/brownvc/R3GAN-ImgNet-32x32/resolve/main/imagenet-32x32.pkl',
+        'resolution': 32,
+        'num_classes': 1000,
+        'type': 'r3gan',
+        'description': 'R3GAN ImageNet 32x32 - 1000-class conditional (FID: 1.27)',
+    },
+}
+
+
+def get_r3gan_models():
+    """Get list of available R3GAN models in the same format as consolidate_models()"""
+    return list(R3GAN_MODELS.values())
+
+
 def download_weights(url, output):
   '''Download model weights from URL'''
 
@@ -41,7 +97,7 @@ _models_cache = None
 
 
 def consolidate_models():
-  '''Consolidate JSON dictionaries of pre-trained StyleGAN(2) weights'''
+  '''Consolidate JSON dictionaries of pre-trained StyleGAN(2) and R3GAN weights'''
   global _models_cache
 
   # Return cached result if available
@@ -63,13 +119,23 @@ def consolidate_models():
   r = requests.get(stylegan2_url)
   models_stylegan2 = json.loads(r.text)
 
-  # Consolidate StyleGAN and StyleGAN2 weights
-  all_models = models_stylegan + models_stylegan2
+  # Get R3GAN models
+  models_r3gan = get_r3gan_models()
+
+  # Consolidate StyleGAN, StyleGAN2, and R3GAN weights
+  all_models = models_stylegan + models_stylegan2 + models_r3gan
 
   # Cache the result
   _models_cache = all_models
 
   return all_models
+
+
+def is_r3gan_style(style):
+  """Check if a style name refers to an R3GAN model"""
+  if isinstance(style, str):
+    return style.lower() in R3GAN_MODELS or style.lower().startswith('r3gan')
+  return False
 
 
 def get_spec_norm(wav, sr, n_mels, hop_length):


### PR DESCRIPTION
R3GAN (NeurIPS 2024) is a modern GAN baseline that achieves better visual quality than StyleGAN2 with a simpler architecture.

Key changes:
- Add R3GAN model registry with 5 pretrained models (FFHQ, CIFAR-10, ImageNet)
- Add setup_r3gan() function for repository cloning
- Update stylegan_init() to handle R3GAN model downloads
- Add BFloat16 support (R3GAN prefers BFloat16 over FP16)
- Add fallback to direct G(z,c) call for R3GAN model variations
- Add show_r3gan_styles() function for model discovery
- Update README with R3GAN usage examples and model table

Available R3GAN models:
- r3gan_ffhq_256: 256x256 faces, FID 2.75 (vs StyleGAN2's 3.78)
- r3gan_ffhq_64: 64x64 faces, FID 1.95
- r3gan_cifar10: 32x32, 10 classes, FID 1.96
- r3gan_imagenet_64: 64x64, 1000 classes, FID 2.09
- r3gan_imagenet_32: 32x32, 1000 classes, FID 1.27

Paper: "The GAN is dead; long live the GAN! A Modern Baseline GAN" https://arxiv.org/abs/2501.05441